### PR TITLE
fix: change some className in postcard

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -23,7 +23,7 @@ export default function PostCard({
           }
         `}
       </style>
-      <div className="max-h-max flex flex-col flex-wrap justify-start shadow-lg rounded-md overflow-hidden font-sans print:shadow-none print:border">
+      <div className="flex flex-col flex-wrap justify-start shadow-lg rounded-md overflow-hidden font-sans print:shadow-none print:border">
         <img className="h-[10rem] object-cover w-full" src={cover} alt={slug} />
         <div className="p-4 print:p-2">
           <div className="flex flex-wrap gap-1 mb-2">
@@ -44,7 +44,7 @@ export default function PostCard({
             <p className="text-base leading-relaxed text-gray-500 mb-2 font-serif">{desc}</p>
           </div>
           <a className="group" href={`https://github.com/${github}`}>
-            <div className="flex gap-2 items-center justify-start">
+            <div className="flex items-center justify-start">
               <img
                 className="rounded-full shadow-md"
                 src={`https://github.com/${github}.png`}
@@ -52,7 +52,7 @@ export default function PostCard({
                 height="32"
                 alt="author"
               />
-              <span className="text-sm text-left text-gray-700 group-hover:text-primary-600">{author}</span>
+              <span className="text-sm ml-2 text-left text-gray-700 group-hover:text-primary-600">{author}</span>
             </div>
           </a>
         </div>


### PR DESCRIPTION
Fixes:
- Post not appearing in ios. I think we can just remove `max-h-max` because the image has fixed height and the description is clamped to 2 lines already.
![post not visible](https://i.imgur.com/eVxQgMP.jpg)
- No gap between avatar and username in ios
![no gap](https://i.imgur.com/paMn1nB.jpg)