### PR TITLE
fix: 100vw causes horizontal scrollbar

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,6 +3,10 @@ body {
   @apply p-0 m-0 box-border;
 }
 
+body {
+  overflow-x: hidden;
+}
+
 #__next {
   @apply relative;
 }


### PR DESCRIPTION
This behaviour will only occur at `/posts/[slug]` as much as i know. What causes this is the 100vw style, which was originally passed from tailwind to the header tag `w-screen`.

One easy braindead way to fix this is to keep the horizontal scrollbar shut. This is NOT an ideal way to fix it, and could be considered as a bad practice.

However, i see that the header tag is sticking up to the main tag, which does not have the full width corresponding to the screen. This can be fixed, the main tag's width should be at 100% relative to the screen width. Then make a standalone wrapper for the content thus the header could rather use 100% width property that's relative to the main tag. The post-structure could be something like:

```html
<main>
    <header />
    <div class="wrapper-for-content">...content</div>
    <footer />
</main>
```
![screenshot](https://i.imgur.com/G3Fpjqg.png)

Articles related to this PR:
  - [https://destroytoday.com/blog/100vw-and-the-horizontal-overflow-you-probably-didnt-know-about](https://destroytoday.com/blog/100vw-and-the-horizontal-overflow-you-probably-didnt-know-about)
  - [https://tepy.dev/til/why-100vw-causes-horizontal-scroll](https://tepy.dev/til/why-100vw-causes-horizontal-scroll)