### PR TITLE
fix: hover events causing confusion on search tags bcz it has the sam…

### DIFF
--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { ChevronUpIcon } from '~/icons';
 
@@ -27,9 +28,10 @@ export function BackToTop() {
 
   return (
     <div
-      className={`fixed bottom-10 right-9 w-8 h-8 flex items-center justify-center bg-black rounded cursor-pointer print:hidden ${
-        !show && 'hidden'
-      }`}
+      className={clsx(
+        'fixed bottom-10 right-9 w-8 h-8 flex items-center justify-center bg-black rounded cursor-pointer print:hidden',
+        !show && 'hidden',
+      )}
       onClick={scrollToTop}
     >
       <ChevronUpIcon />

--- a/components/EnhancedSection.tsx
+++ b/components/EnhancedSection.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useState, type ReactNode, type ReactElement, type PropsWithChildren } from 'react';
 
 // From https://stackoverflow.com/a/60564620
@@ -32,9 +33,10 @@ function CopyButton({ text = '' }) {
 
   return (
     <button
-      className={`absolute top-0 right-0 px-2 py-1 m-2 duration-200 text-sm rounded ${
-        clicked ? 'bg-white' : 'text-white bg-black'
-      }`}
+      className={clsx(
+        'absolute top-0 right-0 px-2 py-1 m-2 duration-200 text-sm rounded',
+        clicked ? 'bg-white' : 'text-white bg-black',
+      )}
       onClick={handleClickCopy}
       onBlur={handleBlur}
     >

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { GithubIcon, TelegramIcon, SearchIcon } from '~/icons';
@@ -19,10 +20,10 @@ export function Navbar() {
           {['home', 'blog', 'about'].map((route, idx) => (
             <Link href={`/${route === 'home' ? '' : route}`} key={`${idx}-${route}`}>
               <a
-                className={`flex-inline uppercase text-center hover:text-primary-600 transition duration-300 ${getActiveClass(
-                  route,
-                  route === 'home',
-                )}`}
+                className={clsx(
+                  'flex-inline uppercase text-center hover:text-primary-600 transition duration-300',
+                  getActiveClass(route, route === 'home'),
+                )}
               >
                 {route}
               </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fontsource/rubik": "^4.5.10",
         "@giscus/react": "2.1.1",
         "@svgr/webpack": "^6.3.1",
+        "clsx": "^1.2.1",
         "gray-matter": "4.0.3",
         "next": "^12.2.3",
         "next-mdx-remote": "4.1.0",
@@ -3329,6 +3330,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -10949,6 +10958,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@fontsource/rubik": "^4.5.10",
     "@giscus/react": "2.1.1",
     "@svgr/webpack": "^6.3.1",
+    "clsx": "^1.2.1",
     "gray-matter": "4.0.3",
     "next": "^12.2.3",
     "next-mdx-remote": "4.1.0",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -6,6 +6,8 @@ import { useDebounce } from '~/hooks/use-debounce';
 import type { PostField, PostFieldName } from '~/types/post';
 import { PostCard } from '~/components/PostCard';
 import { filterPostsByKeywords, getAllPosts } from '~/services';
+import clsx from 'clsx';
+import { isMobile, isStandalone } from '~/utils/helpers';
 
 type SearchProps = {
   posts: PostField[];
@@ -71,6 +73,8 @@ export default function Search({ posts }: SearchProps) {
 
     setSelectedTags((prev) => [...prev, fieldName]);
   };
+
+  const hasHoverEvent = !isMobile() && !isStandalone();
   return (
     <>
       <NextSeo
@@ -97,9 +101,11 @@ export default function Search({ posts }: SearchProps) {
           {filter.map((tag, idx) => (
             <div
               key={idx}
-              className={`border border-black hover:bg-black/60 hover:text-white cursor-pointer px-2 py-1 transition duration-300 ${activeClassFor(
-                tag,
-              )}`}
+              className={clsx(
+                'border border-black cursor-pointer px-2 py-1 transition duration-300',
+                activeClassFor(tag),
+                hasHoverEvent && 'hover:bg-black/60 hover:text-white',
+              )}
               onClick={() => toggleSelectedField(tag)}
             >
               <span className="text-base capitalize select-none">{tag}</span>

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,35 @@
+export const isSSR: boolean = typeof window === 'undefined';
+
+export const androidOrIOS = (): 'android' | 'ios' | undefined => {
+  if (!isSSR) {
+    const userAgent = navigator.userAgent;
+    if (/android/i.test(userAgent)) {
+      return 'android';
+    }
+
+    if (/iPad|iPhone|iPod/i.test(userAgent)) {
+      return 'ios';
+    }
+  }
+
+  return undefined;
+};
+
+export const isMobile = (): boolean => {
+  const device = androidOrIOS();
+  return device === 'android' || device === 'ios';
+};
+
+export const isStandalone = (): boolean => {
+  if (!isSSR) {
+    let displayMode = 'browser tab';
+
+    if (window && window.matchMedia('(display-mode: standalone)').matches) {
+      displayMode = 'standalone';
+    }
+
+    return displayMode === 'standalone';
+  }
+
+  return false;
+};


### PR DESCRIPTION
I guess the reason behind unexpected behavior when clicking tags on search page (looks like the state been delayed, but it's actually not), because each tags acquired a hover event that causing the changes of color, but unfortunately, the color is almost the same with one got implemented by active class.

I also wrap every conditional rendering classes inside clsx library. 
in most cases doing something like will causing unexpected bug inside the DOM

```
<div className={`foo ${someConditionReturningBool && 'bar'}`} />
```

sometimes, that code will be rendered as `<div class="foo false"></div>`

when encountering a case like this, you'll find yourself doing unnecessary ternary that return empty string as exception

or maybe you're very often find a piece of code like this

```
<div className={`foo ${someConditionReturningBool ? 'bar' : ''}`} />
```

will be resulting as `<div class="foo "></div>` <- see that unnecessary space after `foo`?