### PR TITLE
fix: spacing page title

### DIFF
--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -1,0 +1,8 @@
+import clsx from 'clsx';
+import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+
+type PageTitleProps = DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+
+export function PageTitle({ className, ...restProps }: PageTitleProps) {
+  return <h1 className={clsx('text-left text-2xl uppercase font-bold font-sans my-10', className)} {...restProps} />;
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,6 @@
 import { NextSeo } from 'next-seo';
 import siteData from 'data/site';
+import { PageTitle } from '~/components/PageTitle';
 import type { GetStaticProps, InferGetStaticPropsType } from 'next';
 
 interface Contributor {
@@ -38,7 +39,7 @@ export default function About({ contributors = [] }: InferGetStaticPropsType<typ
       />
       <div>
         <div className="w-full text-lg font-serif">
-          <h1 className="text-left text-2xl font-bold py-8 uppercase font-sans">Tentang Teknologi Umum</h1>
+          <PageTitle>Tentang Teknologi Umum</PageTitle>
           <p className="pb-3">
             <strong className="font-bold">Teknologi Umum</strong> merupakan suatu paguyuban yang berdiri sejak tahun
             2021 awal karena keresahan sang pencipta, La Ode Muhammad Al Fatih yang kesulitan untuk mengungkapkan rasa,

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -2,6 +2,7 @@ import { NextSeo } from 'next-seo';
 import siteData from 'data/site';
 import { getAllPosts } from '~/services';
 import { PostCard } from '~/components/PostCard';
+import { PageTitle } from '~/components/PageTitle';
 import type { PostField } from '~/types/post';
 
 export default function Blog({ posts }) {
@@ -25,7 +26,7 @@ export default function Blog({ posts }) {
           }
         }
       `}</style>
-      <h1 className="text-left uppercase text-2xl font-bold my-8">Blog Posts</h1>
+      <PageTitle>Blog Posts</PageTitle>
       <div className="posts grid lg:grid-cols-3 gap-4">
         {posts.map((post: PostField, idx: number) => (
           <PostCard {...post} key={idx} />


### PR DESCRIPTION
#### before

<img width="777" alt="Screen Shot 2022-10-02 at 09 18 58" src="https://user-images.githubusercontent.com/45778229/193435016-4b45df31-f41b-4bf8-93dc-b9e590516550.png">
<img width="823" alt="Screen Shot 2022-10-02 at 09 19 16" src="https://user-images.githubusercontent.com/45778229/193435029-92139fec-0e36-4613-b758-6f4599f95020.png">

#### after

<img width="808" alt="Screen Shot 2022-10-02 at 09 19 29" src="https://user-images.githubusercontent.com/45778229/193435038-a1ebd19b-e6d9-4738-9c8b-6abf90bb4d47.png">
<img width="786" alt="Screen Shot 2022-10-02 at 09 19 48" src="https://user-images.githubusercontent.com/45778229/193435048-4b0f1fef-fbdb-429f-8322-ff3f219c1114.png">
